### PR TITLE
Fix message retrieval status

### DIFF
--- a/mqttclient/mqttclient.cpp
+++ b/mqttclient/mqttclient.cpp
@@ -405,15 +405,17 @@ namespace mqttcpp
             return false;
         }
 
-        std::function<void()> fn = [this, &msg]() mutable {
+        bool retrieved{false};
+        std::function<void()> fn = [this, &msg, &retrieved]() mutable {
             lg lock(consumeGuard_);
             mqtt::const_message_ptr msg_ptr;
-            if (client_.try_consume_message(&msg_ptr))
+            retrieved = client_.try_consume_message(&msg_ptr);
+            if (retrieved && msg_ptr)
             {
                 msg = msg_ptr->to_string();
             }
         };
-        return common_try(fn, "Pop message");
+        return common_try(fn, "Pop message") && retrieved;
     }
 
 } // namespace mqttcpp


### PR DESCRIPTION
## Summary
- ensure `get_next_message` actually reports if a message was retrieved

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_6846a9b9c87483249589a7d365b402e9